### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for querying and analyzing Wazuh security logs stored in OpenSearch.
 
+<a href="https://glama.ai/mcp/servers/@cyberbalsa/mcp-opensearch-js">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cyberbalsa/mcp-opensearch-js/badge" alt="OpenSearch Server MCP server" />
+</a>
+
 ## Features
 
 - Search for security alerts with advanced filtering


### PR DESCRIPTION
This PR adds a badge for the [OpenSearch MCP Server](https://glama.ai/mcp/servers/@cyberbalsa/mcp-opensearch-js) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cyberbalsa/mcp-opensearch-js">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cyberbalsa/mcp-opensearch-js/badge" alt="OpenSearch Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.